### PR TITLE
Let redis count element

### DIFF
--- a/pylimit/pyratelimit.py
+++ b/pylimit/pyratelimit.py
@@ -75,9 +75,9 @@ class PyRateLimit(object):
             connection.zadd(namespace, current_time, current_time)
         else:
             current_count = 1   # initialize at 1 to compensate the case that this attempt is not getting counted
-        connection.zrange(namespace, 0, -1)
+        connection.zcard(namespace)
         redis_result = connection.execute()
-        current_count += len(redis_result[-1])
+        current_count += redis_result[-1]
         if current_count <= self.limit:
             can_attempt = True
         return can_attempt


### PR DESCRIPTION
Instead of receiving all results assign to the requested key

Receiving a counter of redis instead of receiving all element of the set, gives an improvement of performance. In our production environment the difference can be 10 seconds  vs. 20ms for sets with 1000 elements
